### PR TITLE
Moved competition id to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ export KILOMETRIKISA_DB=
 export KILOMETRIKISA_DBUSER=
 export KILOMETRIKISA_DBPASSWORD=
 export KILOMETRIKISA_DBHOST=
+export KILOMETRIKISA_COMPETITION_ID= # 43(?) for summer 2020
 
 # https://www.strava.com/settings/api
 export STRAVA_ACCESS_TOKEN=

--- a/app/models/SyncModel.js
+++ b/app/models/SyncModel.js
@@ -177,7 +177,7 @@ var SyncModel = {
           Kilometrikisa.updateLog(
             kilometrikisaToken,
             kilometrikisaSessionId,
-            41,
+            process.env.KILOMETRIKISA_COMPETITION_ID,
             activities[date].distance,
             date,
             function() {
@@ -193,7 +193,7 @@ var SyncModel = {
           Kilometrikisa.updateMinuteLog(
             kilometrikisaToken,
             kilometrikisaSessionId,
-            41,
+            process.env.KILOMETRIKISA_COMPETITION_ID,
             activities[date].hours,
             activities[date].minutes,
             date,


### PR DESCRIPTION
## Description of change
Moved competition id to environment variables to reduce needed commits when competition changes

## How has this been tested?
Not tested as there is no active competition
