### PR TITLE
Add WWW subdomain to application url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An application to fill the gap between [Strava](https://strava.com/) and [Kilometrikisa](https://www.kilometrikisa.fi/).
 
-Live at [https://strava2kilometrikisa.com](https://strava2kilometrikisa.com)
+Live at [https://www.strava2kilometrikisa.com](https://www.strava2kilometrikisa.com)
 
 ## Development
 


### PR DESCRIPTION
Application web address doesn't redirect to application without www -subdomain

## Description of change
Add "www." to application url. Old url doesn't redirect to application website without that

## How has this been tested?
Tested with Firefox 88.0 and Google Chrome Version 90.0.4430.93
