### PR TITLE
Add sync for e-bikes

### DIFF
--- a/app/assets/js/index.js
+++ b/app/assets/js/index.js
@@ -22,6 +22,27 @@ $(document).ready(function() {
       },
     });
   });
+  $('#cmn-toggle-2').change(function(e) {
+    var value = $(e.target).is(':checked');
+    var url = '';
+    var status = '';
+    if (value) {
+      url = 'enableebike';
+      status = 'enabled';
+    } else {
+      url = 'disableebike';
+      status = 'disabled';
+    }
+    $.ajax({
+      url: url,
+      success: function() {
+        $('.js-ebike-status').html(status);
+      },
+      error: function() {
+        alert("Couldn't save status!");
+      },
+    });
+  });
 
   if ($('.js-isauthenticated').length > 0) {
     $.ajax({

--- a/app/controllers/Sync.js
+++ b/app/controllers/Sync.js
@@ -28,6 +28,7 @@ var SyncController = {
       // Render template.
       res.render('sync-index', {
         autosync: user.autosync,
+        ebike: user.ebike,
       });
     });
   },
@@ -52,6 +53,7 @@ var SyncController = {
         // Get activities.
         SyncModel.getStravaActivities(
           user.stravaToken,
+          user.ebike,
           function(activities) {
             res.render('sync-preview', {
               activities: activities,
@@ -90,6 +92,7 @@ var SyncController = {
         user.stravaToken,
         user.kilometrikisaToken,
         user.kilometrikisaSessionId,
+        user.ebike,
 
         // Sync success.
         function(activities) {
@@ -151,6 +154,36 @@ var SyncController = {
   disableAutosync: function(req, res, next) {
     User.findOne({ stravaUserId: req.session.stravaUserId }, function(err, user) {
       user.set('autosync', false);
+      user.save(function() {
+        res.redirect('/account');
+      });
+    });
+  },
+
+  /**
+   * Set e-bike sync to true and redirect to account page
+   * @param {*} req 
+   * @param {*} res 
+   * @param {*} next 
+   */
+  enableEBikeSync: function(req, res, next) {
+    User.findOne({ stravaUserId: req.session.stravaUserId }, function(err, user) {
+      user.set('ebike', true);
+      user.save(function() {
+        res.redirect('/account');
+      });
+    });
+  },
+
+  /**
+   * Set e-bike sync to false and redirect to account page
+   * @param {*} req 
+   * @param {*} res 
+   * @param {*} next 
+   */
+  disableEBikeSync: function(req, res, next) {
+    User.findOne({ stravaUserId: req.session.stravaUserId }, function(err, user) {
+      user.set('ebike', false);
       user.save(function() {
         res.redirect('/account');
       });

--- a/app/cron.js
+++ b/app/cron.js
@@ -112,6 +112,7 @@ var cron = {
             user.stravaToken,
             user.kilometrikisaToken,
             user.kilometrikisaSessionId,
+            user.ebike,
             function(activities) {
               Log.log('Activities synced automatically.', JSON.stringify(activities), user.stravaUserId);
               console.log(Object.keys(activities).length + ' activities synced');

--- a/app/index.js
+++ b/app/index.js
@@ -100,7 +100,7 @@ app.get('/dosync', (req, res, next) => {
   Sync.doSync(req, res, next);
 });
 
-// Disable autosync.
+// Enable autosync.
 app.get('/enableautosync', (req, res, next) => {
   Sync.enableAutosync(req, res, next);
 });
@@ -108,6 +108,16 @@ app.get('/enableautosync', (req, res, next) => {
 // Disable autosync.
 app.get('/disableautosync', (req, res, next) => {
   Sync.disableAutosync(req, res, next);
+});
+
+// Enable e-bike sync.
+app.get('/enableebike', (req, res, next) => {
+  Sync.enableEBikeSync(req, res, next);
+});
+
+// Disable e-bike sync.
+app.get('/disableebike', (req, res, next) => {
+  Sync.disableEBikeSync(req, res, next);
 });
 
 // isAuthenticated

--- a/app/lib/kilometrikisa.js
+++ b/app/lib/kilometrikisa.js
@@ -192,10 +192,11 @@ var kilometrikisa = {
    * @param  {String}   sessionId Session id.
    * @param  {Integer}   contestId Contest id. Changes every year.
    * @param  {Float}   distance  Distance for a day.
+   * @param  {Integer}   ebike   Is daily ride added as e-bike ride
    * @param  {String}   date      Date. YYYY-MM-DD, example: 2016-04-05
    * @param  {Function} callback  Called on success.
    */
-  updateLog: function(token, sessionId, contestId, distance, date, successCallback, errorCallback) {
+  updateLog: function(token, sessionId, contestId, distance, ebike, date, successCallback, errorCallback) {
     // curl -X POST
     // -e https://www.kilometrikisa.fi/contest/log/
     // -d "contest_id=17&km_amount=10&km_date=2016-04-05&csrfmiddlewaretoken=9Jw5rFmg4LGYr9sT23oOZNQtzFFluWWF"
@@ -213,6 +214,7 @@ var kilometrikisa = {
       data: {
         contest_id: contestId,
         km_amount: distance,
+        is_electric: ebike,
         km_date: date,
         csrfmiddlewaretoken: token,
       },
@@ -254,10 +256,11 @@ var kilometrikisa = {
    * @param  {Integer}   contestId Contest id. Changes every year.
    * @param  {Float}   hours  Hours.
    * @param  {Float}   minutes  Minutes.
+   * @param  {Integer}   ebike   Is daily ride added as e-bike ride
    * @param  {String}   date      Date. YYYY-MM-DD, example: 2016-04-05
    * @param  {Function} callback  Called on success.
    */
-  updateMinuteLog: function(token, sessionId, contestId, hours, minutes, date, successCallback, errorCallback) {
+  updateMinuteLog: function(token, sessionId, contestId, hours, minutes, ebike, date, successCallback, errorCallback) {
     // curl -X POST
     // -e https://www.kilometrikisa.fi/contest/log/
     // -d "contest_id=17&km_amount=10&km_date=2016-04-05&csrfmiddlewaretoken=9Jw5rFmg4LGYr9sT23oOZNQtzFFluWWF"
@@ -276,6 +279,7 @@ var kilometrikisa = {
         contest_id: contestId,
         hours: hours,
         minutes: minutes,
+        is_electric: ebike,
         date: date,
         csrfmiddlewaretoken: token,
       },

--- a/app/models/SyncModel.js
+++ b/app/models/SyncModel.js
@@ -21,7 +21,7 @@ var SyncModel = {
    * @param Function Callback.
    * @return {[type]} [description]
    */
-  getStravaActivities: function(stravaToken, successCallback, errorCallback) {
+  getStravaActivities: function(stravaToken, syncEBike, successCallback, errorCallback) {
     // Example input:
     // var activities = [ { id: 540164876,
     //     resource_state: 2,
@@ -81,7 +81,8 @@ var SyncModel = {
       if (!err && activities) {
         var response = {};
         for (var i in activities) {
-          if ((activities[i]['type'] == 'Ride' || activities[i]['type'] == 'EBikeRide') && activities[i]['trainer'] == false) {
+          if ((activities[i]['type'] == 'Ride' || (syncEBike && activities[i]['type'] == 'EBikeRide'))
+              && activities[i]['trainer'] == false) {
             // Format date.
             var date = new Date(activities[i]['start_date_local']);
             var dateFormatted =
@@ -143,6 +144,7 @@ var SyncModel = {
     stravaToken,
     kilometrikisaToken,
     kilometrikisaSessionId,
+    syncEBike,
     successCallback,
     errorCallback,
   ) {
@@ -163,6 +165,7 @@ var SyncModel = {
     // Get activities from Strava.
     SyncModel.getStravaActivities(
       stravaToken,
+      syncEBike,
       function(activities) {
         // Counters. We do two requests per each activity. One for distance
         // and one for time.

--- a/app/models/SyncModel.js
+++ b/app/models/SyncModel.js
@@ -81,7 +81,7 @@ var SyncModel = {
       if (!err && activities) {
         var response = {};
         for (var i in activities) {
-          if (activities[i]['type'] == 'Ride' && activities[i]['trainer'] == false) {
+          if ((activities[i]['type'] == 'Ride' || activities[i]['type'] == 'EBikeRide') && activities[i]['trainer'] == false) {
             // Format date.
             var date = new Date(activities[i]['start_date_local']);
             var dateFormatted =
@@ -94,6 +94,7 @@ var SyncModel = {
               response[dateFormatted] = {
                 distance: 0,
                 seconds: 0,
+                isEBike: false,
               };
             }
 
@@ -102,6 +103,12 @@ var SyncModel = {
 
             // Append time in seconds.
             response[dateFormatted].seconds += activities[i]['moving_time'];
+
+            // There is no possibility to add 'acoustic' and e-bike rides for same day so if there is e-bike ride for a day, 
+            // all rides are marked as e-bike ride
+            if (activities[i]['type'] == 'EBikeRide') {
+              response[dateFormatted].isEBike = true;
+            }
           }
         }
 
@@ -179,6 +186,7 @@ var SyncModel = {
             kilometrikisaSessionId,
             process.env.KILOMETRIKISA_COMPETITION_ID,
             activities[date].distance,
+            activities[date].isEBike ? 1 : 0,
             date,
             function() {
               cb();
@@ -196,6 +204,7 @@ var SyncModel = {
             process.env.KILOMETRIKISA_COMPETITION_ID,
             activities[date].hours,
             activities[date].minutes,
+            activities[date].isEBike ? 1 : 0,
             date,
             function() {
               cb();

--- a/app/models/UserModel.js
+++ b/app/models/UserModel.js
@@ -21,6 +21,9 @@ var UserSchema = new mongoose.Schema({
   // Sync kilometers automatically.
   autosync: { type: Boolean },
 
+  // Sync e-bike kilometers.
+  ebike: { type: Boolean},
+
   // If true, we know that notification email about session timeout
   // is sent to user.
   notifiedByEmail: { type: Boolean },

--- a/app/views/sync-index.ejs
+++ b/app/views/sync-index.ejs
@@ -30,6 +30,15 @@
                                 <input id="cmn-toggle-1" class="cmn-toggle cmn-toggle-round" type="checkbox" <% if (autosync) { %>checked<% } %>>
                                 <label for="cmn-toggle-1"></label>
                             </div>
+			   
+                            <p>
+                                E-bike synchronization is <b class="js-ebike-status"><% if (ebike) { %>enabled<% } else { %>disabled<% } %></b>.
+                            </p>
+
+                            <div class="switch">
+                                <input id="cmn-toggle-2" class="cmn-toggle cmn-toggle-round" type="checkbox" <% if (ebike) { %>checked<% } %>>
+                                <label for="cmn-toggle-2"></label>
+                            </div>
 
                             <a class="manual-sync" href="/manualsync">
                                 <img class="manual-sync__icon" src="/img/gear.svg" />
@@ -44,6 +53,9 @@
                         <div class="container-box container-box--grey text-center">
                             <p>
                                 Automatic synchronization will copy your activities from the last five days from Strava to Kilometrikisa. Synchronization will occur once per day. Please note that if you have entered kilometers manually at Kilometrikisa <b>they will be overwritten!</b>
+                            </p>
+                            <p>
+                                If e-bike synchronization is enabled and e-bike rides is found, all rides on same day is marked as e-bike ride as Kilomterikisa doesn't support multiple inputs for single day.
                             </p>
                         </div>
 

--- a/app/views/sync-preview.ejs
+++ b/app/views/sync-preview.ejs
@@ -28,12 +28,18 @@
                                     <th>Date</th>
                                     <th>Distance</th>
                                     <th>Duration</th>
+                                    <th />
                                   </tr>
                                   <% for (var date in activities) { %>
                                     <tr>
                                       <td><%=date%></td>
                                       <td><%=activities[date].distance%> km<br></td>
                                       <td><%=activities[date].hours%> h, <%=activities[date].minutes%> min</td>
+                                      <% if (activities[date].isEBike) { %>
+                                        <td>Electric</td>
+                                      <% } else { %>
+                                        <td />
+                                      <% } %>
                                     </tr>
                                   <% } %>
                               </table>


### PR DESCRIPTION
## Description of change
Add support to synchronize also e-bike rides

As Kilometrikisa supports only one activity per day, this will mark daily entry as electric if there is at least one ride with electric bike

## Related issue
[Add support for electric bikes #22](https://github.com/jaamo/strava2kilometrikisa/issues/22) 

## How has this been tested?
Tested by using local development environment, Windows 10, node version 12.4.1

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6770071/117137790-ea341d80-adb2-11eb-8b13-f11f5c63ddc1.png)
![image](https://user-images.githubusercontent.com/6770071/117137812-f0c29500-adb2-11eb-93fe-399a5f61dcbc.png)
![image](https://user-images.githubusercontent.com/6770071/117137827-f61fdf80-adb2-11eb-83ed-8a5341d632ff.png)

<!--- Optional, but useful -->
