### PR TITLE
Add CI linting w/ GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: CI
-on:
-  pull_request:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: npm install
+      - run: npm run lint


### PR DESCRIPTION
## Description of change
<!--- Describe your changes. Why are these changes required? What problem does it solve? -->

Adds Continuous Integration linting using GitHub Actions. This should help development by making it easy to notice non-standard code automatically in PRs.


## How has this been tested?
<!--- Please describe how you tested your changes -->

Tested in my fork[ to fail with non-linted code](https://github.com/nikosavola/strava2kilometrikisa/actions/runs/1081233382) and to [succeed with linted code](https://github.com/nikosavola/strava2kilometrikisa/actions/runs/1081223708).
